### PR TITLE
feat: add onAdd reconcilation to Map and Set signals

### DIFF
--- a/lib/src/main/java/eu/nitonfx/signaling/api/MapSignal.java
+++ b/lib/src/main/java/eu/nitonfx/signaling/api/MapSignal.java
@@ -1,6 +1,10 @@
 package eu.nitonfx.signaling.api;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 /**
  * A MapSignal is a reactive map that allows for tracking changes to its entries.
@@ -21,7 +25,19 @@ public interface MapSignal<K, V> extends Map<K,V> {
     SignalLike<V> getSignal(K key);
 
     /**
+     * Similar to {@link #getSignal(Object)} but based on a dynamic/reactive key where the returned signal is updated
+     * when the key supplier does
+     * @param key a function to provide a key to look up. Should be a {@link SignalLike} or at least be based on one
+     * @return a signal that changes when the key or the value the key points to changes
+     */
+    Supplier<V> get(Supplier<? extends K> key);
+
+    /**
      * @return the map of entries without tracking
      */
     Map<K,V> getUntracked();
+
+    @NotNull SetSignal<K> keySetSignal();
+
+    EffectHandle onPut(BiConsumer<K, SignalLike<V>> o);
 }

--- a/lib/src/main/java/eu/nitonfx/signaling/api/SetSignal.java
+++ b/lib/src/main/java/eu/nitonfx/signaling/api/SetSignal.java
@@ -1,6 +1,7 @@
 package eu.nitonfx.signaling.api;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * A SetSignal is a reactive set that allows for tracking changes to its elements.
@@ -11,9 +12,14 @@ import java.util.Set;
 public interface SetSignal<E> extends Set<E> {
 
     /**
-     * Returns the set of elements without tracking.
+     * Returns the set of elements without tracking reads.
      *
-     * @return the set of elements without tracking
+     * Writes <i>might</i> still be forwarded to the signal list and trigger effects or not.
+     * This means that it is not recommended to modify the returned value
+     *
+     * @return the set of elements without tracking reads
      */
     Set<E> getUntracked();
+
+    EffectHandle onAdd(Consumer<E> o);
 }

--- a/lib/src/main/java/eu/nitonfx/signaling/collections/HashSetSignal.java
+++ b/lib/src/main/java/eu/nitonfx/signaling/collections/HashSetSignal.java
@@ -1,30 +1,41 @@
 package eu.nitonfx.signaling.collections;
 
-import eu.nitonfx.signaling.api.Context;
-import eu.nitonfx.signaling.api.SetSignal;
-import eu.nitonfx.signaling.api.Signal;
-import eu.nitonfx.signaling.api.SignalLike;
+import eu.nitonfx.signaling.Effect;
+import eu.nitonfx.signaling.api.*;
 import org.jetbrains.annotations.Unmodifiable;
 
-import java.util.AbstractSet;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class HashSetSignal<E> extends AbstractSet<E> implements SetSignal<E> {
-    private final Set<Signal<E>> set = new HashSet<>();
+    private final Set<E> set;
     private final Context cx;
     private final Signal<Integer> size;
+    private final List<Reconciler<E>> reconcilers = new ArrayList<>();
+    private interface Reconciler<T> {
+        void onAdd(T element);
+        void onRemove(T element);
+    }
 
     public HashSetSignal(Context cx) {
-        this.cx = cx;
-        size = cx.createSignal(0);
+        this(cx, Set.of());
+    }
+
+    private void onRemove(E signal) {
+        reconcilers.forEach(it -> it.onRemove(signal));
+    }
+
+    private void onAdd(E signal) {
+        reconcilers.forEach(it -> it.onAdd(signal));
     }
 
     public HashSetSignal(Context cx, Set<E> initial) {
         this.cx = cx;
-        initial.stream().map(cx::createSignal).forEach(set::add);
+        set = new ListenableSet<>(
+                new HashSet<>(initial),
+                this::onAdd, this::onRemove
+        );
         size = cx.createSignal(initial.size());
     }
 
@@ -36,7 +47,7 @@ public class HashSetSignal<E> extends AbstractSet<E> implements SetSignal<E> {
 
     @Override
     public boolean remove(Object o) {
-        var removed = set.remove(cx.createSignal((E) o));
+        var removed = set.remove(o);
         if (removed)
             size.set(set.size());
         return removed;
@@ -44,7 +55,7 @@ public class HashSetSignal<E> extends AbstractSet<E> implements SetSignal<E> {
 
     @Override
     public boolean add(E e) {
-        var changed = set.add(cx.createSignal(e));
+        var changed = set.add(e);
         if (changed)
             size.set(set.size());
         return changed;
@@ -52,25 +63,8 @@ public class HashSetSignal<E> extends AbstractSet<E> implements SetSignal<E> {
 
     @Override
     public Iterator<E> iterator() {
-        var signalingIter = set.iterator();
         size.get();//this is to make sure the size signal is subscribed to
-        return new Iterator<E>() {
-            @Override
-            public boolean hasNext() {
-                return signalingIter.hasNext();
-            }
-
-            @Override
-            public E next() {
-                return signalingIter.next().get();
-            }
-
-            @Override
-            public void remove() {
-                signalingIter.remove();
-                size.set(set.size());
-            }
-        };
+        return set.iterator();
     }
 
     @Override
@@ -81,6 +75,39 @@ public class HashSetSignal<E> extends AbstractSet<E> implements SetSignal<E> {
     @Override
     @Unmodifiable
     public Set<E> getUntracked() {
-        return set.stream().map(SignalLike::getUntracked).collect(Collectors.toSet());
+        return set;
+    }
+
+    @Override
+    public EffectHandle onAdd(Consumer<E> consumer) {
+        record ElementEffectHandle(EffectHandle handle, Object element) {}
+        List<ElementEffectHandle> handles = new ArrayList<>();
+        for (var signal : set) {
+            var handle = cx.createEffect(() -> consumer.accept(signal));
+            handles.add(new ElementEffectHandle(handle, signal));
+        }
+        var reconciler = new Reconciler<E>() {
+            @Override
+            public void onAdd(E signal) {
+                var handle = cx.createEffect(() -> consumer.accept(signal));
+                handles.add(new ElementEffectHandle(handle, signal));
+            }
+
+            @Override
+            public void onRemove(E index) {
+                var element = handles.stream()
+                        .filter(handle -> handle.element.equals(index))
+                        .findFirst()
+                        .orElseThrow();
+                element.handle.cancel();
+                handles.remove(element);
+            }
+        };
+        reconcilers.add(reconciler);
+        return ()->{
+            reconcilers.remove(reconciler);
+            handles.forEach(e -> e.handle.cancel());
+            handles.clear();
+        };
     }
 }

--- a/lib/src/main/java/eu/nitonfx/signaling/collections/ListenableSet.java
+++ b/lib/src/main/java/eu/nitonfx/signaling/collections/ListenableSet.java
@@ -1,0 +1,45 @@
+package eu.nitonfx.signaling.collections;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class ListenableSet<E> extends AbstractSet<E> {
+    private final Set<E> set;
+    private final Consumer<? super E> addListener;
+    private final Consumer<? super E> removeListener;
+
+    public ListenableSet(Set<E> set, Consumer<? super E> addListener, Consumer<? super E> removeListener) {
+        this.set = set;
+        this.addListener = addListener;
+        this.removeListener = removeListener;
+    }
+
+    @Override
+    public boolean add(E e) {
+        var ret = set.add(e);
+        if(ret) addListener.accept(e);
+        return ret;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        var ret = super.remove(o);
+        if(ret) removeListener.accept((E) o);
+        return ret;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return set.iterator();
+    }
+
+    @Override
+    public int size() {
+        return set.size();
+    }
+}


### PR DESCRIPTION
### Pull Request Description

**Title:** feat: add onAdd reconciliation to Map and Set signals

**Description:**
This pull request introduces the `onAdd` reconciliation feature for Map and Set signals. This allows fine grained reactivity to set, remove and update operations on theese structures